### PR TITLE
add samtools prefilter and inverse functionality

### DIFF
--- a/scripts/groc.pl
+++ b/scripts/groc.pl
@@ -31,7 +31,7 @@ OPTIONS:
 
 ## args with defaults
 my $prefilter = "-F3328";
-my $stats_file = "read_filter.stats";
+my $stats_file = "groc_filter.stats";
 my $threads = 1;
 my $reads_1 = "reads_1.fq";
 my $reads_2 = "reads_2.fq";

--- a/scripts/groc.pl
+++ b/scripts/groc.pl
@@ -261,7 +261,7 @@ if ($sort){
 ## print stats
 print "Processed ".commify($read_pairs_count)." pairs\n";
 print STATS "Total pairs: ".commify($read_pairs_count)."\n";
-print STATS "Exclude | Exclude: ".commify($read_pairs_exclude_exclude)."(".percentage($read_pairs_exclude_exclude,$read_pairs_count).")\n";
+print STATS "Exclude | Exclude: ".commify($read_pairs_exclude_exclude)." (".percentage($read_pairs_exclude_exclude,$read_pairs_count).")\n";
 print STATS "Exclude | Unmapped: ".commify($read_pairs_exclude_unmapped)." (".percentage($read_pairs_exclude_unmapped,$read_pairs_count).")\n";
 print STATS "Exclude | Include: ".commify($read_pairs_exclude_include)." (".percentage($read_pairs_exclude_include,$read_pairs_count).")\n";
 print STATS "Include | Include: ".commify($read_pairs_include_include)." (".percentage($read_pairs_include_include,$read_pairs_count).")\n";

--- a/scripts/groc.pl
+++ b/scripts/groc.pl
@@ -111,7 +111,7 @@ if ($sam_file){
       die "[ERROR] samtools error: is samtools in \$PATH?\n";
 
     } else {
-      open (SAM, "samtools view -h $bam_file |") or die $!;
+      open (SAM, "samtools view $bam_file |") or die $!;
     }
   }
 }
@@ -146,20 +146,22 @@ while (my $line_f=<SAM>) {
   ## get info for read 1
   my @fp=split(/\t/,$line_f);
 
-  ## skip supplementary alignments
+  ## skip supplementary alignments in R1
   if($fp[1]&3328){
     next;
 
   } else {
     ## get info for mate
     my $line_s=<SAM>;
-    $read_pairs_count++;
+    my @sp=split(/\t/,$line_s);
 
+    ## skip supplementary alns in R2
+    next if $sp[1]&3328;
+
+    $read_pairs_count++;
     if ($read_pairs_count % 10000000 == 0) {
       print "Processed ".commify($read_pairs_count)." pairs\n";
     }
-
-    my @sp=split(/\t/,$line_s);
 
     ## if read is on the reverse strand...
     if ($fp[1]&16) {

--- a/scripts/groc.pl
+++ b/scripts/groc.pl
@@ -10,7 +10,9 @@ use Getopt::Long;
 my $usage = "
 Filters reads based on a list of contaminant sequences (contig IDs, one per line).
 Excludes only those read-pairs for which both F and R reads map to contaminant contig.
-NOTE: requires samtools in \$PATH
+
+*NOTE1: requires samtools in \$PATH for prefiltering
+*NOTE2: requires SAM/BAM sorted by readname: \`samtools sort -n -o readsort.sam -O sam -T temp [IN_BAM]\`
 
 USAGE: groc.pl -l <bad_contigs.list> [-s mapping.sam | -b mapping.bam [-n -t 16]] [-p <\"-F3328\">] [-f <reads_1.fq>] [-r <reads_2.fq>] [-z] [-o stats.out] [-h]
 
@@ -61,14 +63,13 @@ open (LIST,"$list_file") or die $!;
 
 my %ids;
 
-print "Reading list of contigs...\n";
 while (<LIST>) {
   chomp;
   $ids{$_}=1;
 }
 close LIST;
 
-print "Prefilter for samtools view set to $prefilter...\n";
+print "\nPrefilter for samtools view set to $prefilter...\n";
 
 ## open from sam or bam
 if ($sam_file){
@@ -81,7 +82,7 @@ if ($sam_file){
       die "[ERROR] samtools error: is samtools in \$PATH?\n";
 
     } else {
-      print "Sorting sam file... ";
+      print "Sorting SAM file... ";
 
       ## sort sam file and out put to $sam_file.readsorted.sam
       system("samtools sort -@ $threads -n -O sam -T temp -o $sam_file.readsorted.sam $sam_file") or die $!;
@@ -103,7 +104,7 @@ if ($sam_file){
       die "[ERROR] samtools error: is samtools in \$PATH?\n";
 
     } else {
-      print "Sorting bam file... ";
+      print "Sorting BAM file... ";
 
       ## sort bam file and output to $bam_file.readsorted.sam
       system("samtools sort -@ $threads -n -O sam -T temp -o $bam_file.readsorted.sam $bam_file") or die $!;


### PR DESCRIPTION
Seemed a better idea to do the -F3328 filtering at the samtools view stage, rather than using perl bitwise comparisons (faster). Also added an inverse functionality, i.e. keep reads that **do** map to contigs in -l <list>, rather than keep reads that don't map to contigs in list (default).

Also the bam file sorting works but sometimes crashes, so added a note to recommend to sort bamfile before filtering.

Peace! :-) 
